### PR TITLE
Flexible GPU specification in generate.sh 

### DIFF
--- a/scripts/combine_generate.py
+++ b/scripts/combine_generate.py
@@ -8,6 +8,7 @@ def parse_arguments():
     parser.add_argument('--output_dir', type=str, default='generated/iter1')
     parser.add_argument("--pairs", type=int, default=5)
     parser.add_argument("--numgpu", type=int, default=8)
+    parser.add_argument("--gpu_ids", type=str, default=None)
     return parser.parse_args()
 
 def main():
@@ -15,7 +16,12 @@ def main():
 
     for j in range(args.pairs):
         results = []
-        for i in range(args.numgpu):
+        if args.gpu_ids is not None:
+            gpus = args.gpu_ids.strip("()").split(' ')
+        else:
+            gpus = range(args.numgpu)
+            
+        for i in gpus:
             file_path = f"{args.output_dir}/responses_{i}_{j}.json"
             print(f'Reading from {file_path}')
             with open(file_path) as f:

--- a/scripts/compute_prob.py
+++ b/scripts/compute_prob.py
@@ -15,6 +15,7 @@ def parse_arguments():
     parser.add_argument("--frac_len", type=int, default=0)
     parser.add_argument("--num_gpu", type=int, default=8)
     parser.add_argument("--org", type=str, default="UCLA-AGI")
+    parser.add_argument("--gpu_ids", type=str, default=None)
     return parser.parse_args()
 
 def from_ranks(args):
@@ -24,11 +25,16 @@ def from_ranks(args):
     print(f"Length of dataset: {len(data)}")
 
     scores = [0 for _ in range(len(data))]
-    for idx in range(num_gpu):
-        locals = np.load(f"ranking/{args.output_dir}/{idx}_{idx}.npy")
+    if args.gpu_ids is not None:
+        gpus = args.gpu_ids.strip("()").split(' ')
+    else:
+        gpus = range(args.num_gpu)
+        
+    for data_frac, idx in enumerate(gpus):
+        locals = np.load(f"ranking/{args.output_dir}/{idx}_{data_frac}.npy")
         locals = list(locals)
         for lidx, sc in enumerate(locals):
-            scores[idx * args.frac_len + lidx] = sc
+            scores[data_frac * args.frac_len + lidx] = sc
 
     probs = []
     rm_scores = []

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if stale_egg_info.exists():
 # IMPORTANT: all dependencies should be listed here with their version requirements, if any.
 #   * If a dependency is fast-moving (e.g. transformers), pin to the exact version
 _deps = [
-    "accelerate==0.23.0",
+    "accelerate==0.32.1",
     "bitsandbytes==0.41.2.post2",
     "black==23.1.0",
     "datasets==2.14.6",
@@ -66,8 +66,8 @@ _deps = [
     "scipy",
     "tensorboard",
     "torch==2.1.2",
-    "transformers==4.36.2",
-    "trl==0.7.10",
+    "transformers @ git+https://github.com/huggingface/transformers.git",
+    "trl @ git+https://github.com/huggingface/trl.git",
     "jinja2>=3.0.0",
     "tqdm>=4.64.1",
 ]


### PR DESCRIPTION
## Problem
Current data generation requires GPU ids starting from 0 and consecutive (i.e. cuda device=0..7). Specifying non-consecutive devices is necessary when using public clusters. Simple `export CUDA_VISIBLE_DEVICES=...` didn't work.

## Changes
- `AVAILABLE_GPUS` is added in `scripts/generate.sh` for such usage. For example `AVAILABLE_GPUS=(1 3 5 6)` means running on device 1, 3, 5 and 6. Note that the array in shell requires space separators.
- Change of package versions in `setup.py` that work for me.